### PR TITLE
Python3 compatibility

### DIFF
--- a/navbar/context_processors.py
+++ b/navbar/context_processors.py
@@ -1,4 +1,6 @@
-from utils import get_navtree, get_navbar
+from __future__ import absolute_import
+
+from .utils import get_navtree, get_navbar
 from .settings import (MAX_DEPTH, MARK_SELECTED, SHOW_DEPTH,
                         CRUMBS_STRIP_ROOT, CRUMBS_HOME, ROOT_URL)
 

--- a/navbar/utils.py
+++ b/navbar/utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from .settings import CACHE_PREFIX
 
 
@@ -20,7 +22,7 @@ def _Qperm(user=None):
 
 
 def generate_navtree(user=None, maxdepth=-1):
-    from models import NavBarEntry
+    from .models import NavBarEntry
     if maxdepth == 0:
         return []  # silly...
     permQ = _Qperm(user)
@@ -67,5 +69,5 @@ def get_navtree(user=None, maxdepth=-1):
 
 
 def get_navbar(user=None):
-    from models import NavBarEntry
+    from .models import NavBarEntry
     return NavBarEntry.top.filter(_Qperm(user))

--- a/navbar/utils.py
+++ b/navbar/utils.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from six import iteritems
 
 from .settings import CACHE_PREFIX
 
@@ -47,7 +48,7 @@ def generate_navtree(user=None, maxdepth=-1):
         return [navent(ent, invdepth, parent)
                         for ent in base.filter(active=True).filter(permQ).distinct().order_by('order')]
     tree = navlevel(NavBarEntry.top, maxdepth)
-    urls = sorted(urls.iteritems(), key=lambda x: x[0], reverse=True)
+    urls = sorted(iteritems(urls), key=lambda x: x[0], reverse=True)
     return {'tree': tree, 'byurl': urls}
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 django-categories>=1.0
+six


### PR DESCRIPTION
Hi,

It seemed like you had the most recent copy of django-navbar, I did two commits both to one to make navbar compatible with python3. 

First was to use update to absolute imports. I used from **future** so it should still be compatible with python2.

The second was to use six for a hopefully efficient python 2/3 compatible iteritems for the dictionary lookup. the dictionary might be small enough that returning a list instead of a generator is fine. (allowing dropping the six dependency and using urls.items() instead
